### PR TITLE
add support for object and symbol members

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ _Note:_ remember to `npm install`!
 
 The API follows Redis' [Sorted Set Commands](https://redis.io/commands#sorted_set) as precisely as possible, with a few additional methods such as `.has(member)`.
 
+Note that keys can be strings, symbols, or objects.
+
 ```js
 
 var SortedSet = require('redis-sorted-set');

--- a/lib/set.js
+++ b/lib/set.js
@@ -59,15 +59,11 @@ Z.intersect = function () {
 Z.prototype.add = function (key, value) {
   var current;
 
-  if (key === '__proto__') {
-    throw new Error('invalid key __proto__');
-  }
-
   if (value == null) {
     return this.rem(key);
   }
 
-  current = this._map[key];
+  current = this._map.get(key);
 
   if (current !== undefined) {
     if (value === current) {
@@ -83,7 +79,7 @@ Z.prototype.add = function (key, value) {
     throw new Error('unique constraint violated');
   }
 
-  this._map[key] = value;
+  this._map.set(key, value);
   return current === undefined ? null : current;
 };
 
@@ -146,7 +142,7 @@ Z.prototype.del = function (key) {
 Z.prototype.empty = function () {
   this.length = 0;
   this._level = 1;
-  this._map = Object.create(null);
+  this._map = new Map();
   this._head = new Node(32, null, 0);
   this._tail = null;
 
@@ -164,7 +160,7 @@ Z.prototype.get = function (key) {
 
 
 Z.prototype.has = function (key) {
-  return this._map[key] !== undefined;
+  return this._map.has(key)
 };
 
 
@@ -360,7 +356,7 @@ Z.prototype.rank = function (key) {
   ///  null
   //     if member does not exist
 
-  var value = this._map[key];
+  var value = this._map.get(key);
 
   if (value === undefined) {
     return null;
@@ -392,10 +388,10 @@ Z.prototype.rem = function (key) {
   //   value of the removed key
   //   or null if key does not exist.
 
-  var value = this._map[key];
+  var value = this._map.get(key);
   if (value !== undefined) {
     this._remove(key, value);
-    delete this._map[key];
+    this._map.delete(key);
     return value;
   }
   return null;
@@ -462,7 +458,7 @@ Z.prototype.remRangeByRank = function (start, end) {
   while (node && traversed < end) {
     next = node.next[0].next;
     this._removeNode(node, update);
-    delete this._map[node.key];
+    this._map.delete(node.key);
     removed += 1;
     traversed += 1;
     node = next;
@@ -514,7 +510,7 @@ Z.prototype.remRangeByScore = function (min, max) {
   while (node && node.value <= max) {
     next = node.next[0].next;
     this._removeNode(node, update);
-    delete this._map[node.key];
+    this._map.delete(node.key);
     removed += 1;
     node = next;
   }
@@ -528,7 +524,7 @@ Z.prototype.score = function (member) {
   // Return
   //   number, the score of member in the sorted set.
   //   null, if member does not exist in the sorted set.
-  var score = this._map[member];
+  var score = this._map.get(member);
   return score === undefined ? null : score;
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,372 @@
+{
+  "name": "redis-sorted-set",
+  "version": "2.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "redis-sorted-set",
+      "version": "2.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "chai": "~3.5.0",
+        "mocha": "~3.4.1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha512-7Rfk377tpSM9TWBEeHs0FlDZGoAIei2V/4MdZJoFMBFAK6BqLpxAIUepGRHGdPFgGsLb02PXovC4qddyHvQqTg==",
+      "dev": true
+    },
+    "node_modules/chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha512-eRYY0vPS2a9zt5w5Z0aCeWbrXTEyvk7u/Xf71EzNObrjSCPgMm1Nku/D/u2tiqHBX5j40wWhj54YJLtgn8g55A==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
+      "dev": true,
+      "dependencies": {
+        "graceful-readlink": ">= 1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+      "integrity": "sha512-XMYwiKKX0jdij1QRlpYn0O6gks0hW3iYUsx/h/RLPKouDGVeun2wlMYl29C85KBjnv1vw2vj+yti1ziHsXd7cg==",
+      "dev": true,
+      "dependencies": {
+        "ms": "0.7.2"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "0.1.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/deep-eql/node_modules/type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha512-597ykPFhtJYaXqPq6fF7Vl1fXTKgPdLOntyxpmdzUOKiYGqK7zcnbplj5088+8qJnWdzXhyeau5iVr8HVo9dgg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-mRyN/EsN2SyNhKWykF3eEGhDpeNplMWaW18Bmh76tnOqk5TbELAVwFAYOCmKVssOYFrYvvLMguiA+NXO3ZTuVA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
+      "dev": true
+    },
+    "node_modules/growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha512-RTBwDHhNuOx4F0hqzItc/siXCasGfC4DeWcBamclWd+6jWtBaeB/SGbMkGf0eiQoW7ib8JpvOgnUsmgMHI3Mfw==",
+      "dev": true
+    },
+    "node_modules/has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha512-I5YLeauH3rIaE99EE++UeH2M2gSYo8/2TqDac7oZEH6D/DSQ4Woa628Qrfj1X9/OY5Mk5VvIDQaKCDchXaKrmA==",
+      "deprecated": "Please use the native JSON object instead of JSON 3",
+      "dev": true
+    },
+    "node_modules/lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "node_modules/lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ==",
+      "dev": true
+    },
+    "node_modules/lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha512-EDem6C9iQpn7fxnGdmhXmqYGjCkStmDXT4AeyB2Ph8WKbglg4aJZczNkQglj+zWXcOEEkViK8THuV2JvugW47g==",
+      "dev": true
+    },
+    "node_modules/lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==",
+      "dev": true
+    },
+    "node_modules/lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha512-De+ZbrMu6eThFti/CSzhRvTKMgQToLxbij58LMfM8JnYDNSOjkjTCIaa8ixglOeGh2nyPlakbt5bJWJ7gvpYlQ==",
+      "dev": true
+    },
+    "node_modules/lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha512-IUfOYwDEbI8JbhW6psW+Ig01BOVK67dTSCUAbS58M0HBkPcAv/jHuxD+oJVP2tUCo3H9L6f/8GM6rxwY+oc7/w==",
+      "dev": true,
+      "dependencies": {
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "dev": true
+    },
+    "node_modules/lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
+      "dev": true
+    },
+    "node_modules/lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
+      "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
+      "integrity": "sha512-19d+WPNPG+gCDZvyw8zMcn1MPl72yfZKuTjC/reTOVOFx3VBHXEwxxJyvi9B4G0RV49jjXs0huLKcG58X9S84Q==",
+      "dev": true,
+      "dependencies": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.0",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 0.10.x",
+        "npm": ">= 1.4.x"
+      }
+    },
+    "node_modules/ms": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+      "integrity": "sha512-5NnE67nQSQDJHVahPJna1PQ/zCXMnQop3yUCxjKPNzCxuyPSKWTQ/5Gu5CZmjetwGLWRA+PzeF5thlbOdbQldA==",
+      "dev": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha512-F8dvPrZJtNzvDRX26eNXT4a7AecAvTGljmmnI39xEgSpbHKhQ7N0dO/NTxUExd0wuLHp4zbwYY7lvHq0aKpwrA==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha512-f9Uv6ezcpvCQjJU0Zqbg+65qdcszv3qUQsZfjdRbWiZ7AMenrX1u0lNk9EoWWX6e1F+NULyg27mtdeZ5WhpljA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    }
+  }
+}

--- a/test/set.test.js
+++ b/test/set.test.js
@@ -1,5 +1,8 @@
 var SortedSet = require('../lib/set');
 
+var obj = {};
+var sym = Symbol();
+
 describe('skip map', function () {
   it('should support basic operations', function () {
     var z = new SortedSet();
@@ -8,10 +11,6 @@ describe('skip map', function () {
     expect(z.toArray()).to.eql([]);
     expect(z.range()).to.eql([]);
     expect(z.rangeByScore()).to.eql([]);
-
-    expect(function () {
-      z.add('__proto__', 14);
-    }).to.throw();
 
     z.add('5a600e16', 8);
     z.add('5a600e17', 9);
@@ -26,12 +25,12 @@ describe('skip map', function () {
     expect(z.has('5a600e16')).to.be.ok;
     expect(z.has('5a600e17')).to.be.ok;
     expect(z.has('5a600e18')).to.be.ok;
-    expect(z.has('5a600e19')).to.not.be.ok;
+    expect(z.has(sym)).to.not.be.ok;
 
     expect(z.score('5a600e16')).to.equal(8);
     expect(z.score('5a600e17')).to.equal(12);
     expect(z.score('5a600e18')).to.equal(10);
-    expect(z.score('5a600e19')).to.equal(null);
+    expect(z.score(sym)).to.equal(null);
 
     expect(z.rem('5a600e16')).to.equal(8);
 
@@ -53,7 +52,7 @@ describe('skip map', function () {
     z.add('5a600e11', 6);
     z.add('5a600e12', 17);
     z.add('5a600e13', 11);
-    z.add('5a600e14', 14);
+    z.add(obj, 14);
     z.add('5a600e15', 19);
     z.add('5a600e16', 3);
 
@@ -71,7 +70,7 @@ describe('skip map', function () {
       '5a600e18',
       '5a600e13',
       '5a600e17',
-      '5a600e14',
+      obj,
       '5a600e10',
       '5a600e12',
       '5a600e15',
@@ -80,7 +79,7 @@ describe('skip map', function () {
     expect(z.toArray()).to.eql(z.rangeByScore());
 
     expect(z.rangeByScore(14, 16, { withScores: true })).to.eql([
-      ['5a600e14', 14],
+      [obj, 14],
       ['5a600e10', 16],
     ]);
   });
@@ -94,14 +93,14 @@ describe('skip map', function () {
       z.add('5a600e11', 6);
       z.add('5a600e12', 17);
       z.add('5a600e13', 11);
-      z.add('5a600e14', 14);
+      z.add(obj, 14);
       z.add('5a600e15', 19);
       z.add('5a600e16', 3);
       z.add('5a600e17', 12);
       z.add('5a600e18', 10);
 
-      expect(z.add('5a600e14', null)).to.equal(14);
-      expect(z.add('5a600e19', null)).to.equal(null);
+      expect(z.add(obj, null)).to.equal(14);
+      expect(z.add(sym, null)).to.equal(null);
 
       expect(z).to.have.length(8);
     });
@@ -116,7 +115,7 @@ describe('skip map', function () {
       z.add('5a600e11', 6);
       z.add('5a600e12', 17);
       z.add('5a600e13', 11);
-      z.add('5a600e14', 14);
+      z.add(obj, 14);
       z.add('5a600e15', 19);
       z.add('5a600e16', 3);
       z.add('5a600e17', 12);
@@ -161,14 +160,14 @@ describe('skip map', function () {
       z.add('5a600e11', 6);
       z.add('5a600e12', 17);
       z.add('5a600e13', 11);
-      z.add('5a600e14', 14);
+      z.add(obj, 14);
       z.add('5a600e15', 19);
       z.add('5a600e16', 3);
       z.add('5a600e17', 12);
       z.add('5a600e18', 10);
 
       expect(z.keys()).to.eql(['5a600e16', '5a600e11', '5a600e18', '5a600e13',
-        '5a600e17', '5a600e14', '5a600e10', '5a600e12', '5a600e15']);
+        '5a600e17', obj, '5a600e10', '5a600e12', '5a600e15']);
     });
   });
 
@@ -180,14 +179,14 @@ describe('skip map', function () {
       z.add('5a600e11', 6);
       z.add('5a600e12', 17);
       z.add('5a600e13', 11);
-      z.add('5a600e14', 14);
+      z.add(obj, 14);
       z.add('5a600e15', 19);
       z.add('5a600e16', 3);
       z.add('5a600e17', 12);
       z.add('5a600e18', 10);
 
       expect(z.rangeByScore(14, null, { withScores: true })).to.eql([
-        ['5a600e14', 14],
+        [obj, 14],
         ['5a600e10', 16],
         ['5a600e12', 17],
         ['5a600e15', 19],
@@ -214,12 +213,12 @@ describe('skip map', function () {
       z.add('5a600e11', 6);
       z.add('5a600e12', 17);
       z.add('5a600e13', 11);
-      z.add('5a600e14', 14);
+      z.add(obj, 14);
       z.add('5a600e15', 19);
       z.add('5a600e16', 3);
       z.add('5a600e17', 12);
       z.add('5a600e18', 10);
-      z.add('5a600e19', 14);
+      z.add('5a600e14', 14);
       z.add('5a600f00', 30.0);
       z.add('5a600f01', 30.5);
       z.add('5a600f02', 31.0);
@@ -277,11 +276,11 @@ describe('skip map', function () {
 
       a.add('5a600e10', 16);
       a.add('5a600e12', 10);
-      a.add('5a600e14', 9);
+      a.add(obj, 9);
       a.add('5a600e15', 14);
       a.add('5a600e17', 20);
       a.add('5a600e18', 13);
-      a.add('5a600e19', 15);
+      a.add('5a600e14', 15);
       a.add('5a600e1a', 19);
       a.add('5a600e1b', 7);
       a.add('5a600e1c', 13);
@@ -290,19 +289,19 @@ describe('skip map', function () {
       b.add('5a600e10', 0);
       b.add('5a600e11', 15);
       b.add('5a600e13', 5);
-      b.add('5a600e14', 3);
+      b.add(obj, 3);
       b.add('5a600e15', 14);
       b.add('5a600e17', 12);
-      b.add('5a600e19', 12);
+      b.add('5a600e14', 12);
       b.add('5a600e1b', 16);
       b.add('5a600e1c', 12);
       b.add('5a600e1d', 17);
       b.add('5a600e1f', 3);
 
-      expect(SortedSet.intersect(a, b)).to.eql(['5a600e10', '5a600e14',
-        '5a600e17', '5a600e19', '5a600e1c', '5a600e15', '5a600e1b']);
-      expect(SortedSet.intersect(b, a)).to.eql(['5a600e1b', '5a600e14',
-        '5a600e1c', '5a600e15', '5a600e19', '5a600e10', '5a600e17']);
+      expect(SortedSet.intersect(a, b)).to.eql(['5a600e10', obj,
+        '5a600e14', '5a600e17', '5a600e1c', '5a600e15', '5a600e1b']);
+      expect(SortedSet.intersect(b, a)).to.eql(['5a600e1b', obj,
+        '5a600e1c', '5a600e15', '5a600e14', '5a600e10', '5a600e17']);
     });
 
     it('should intersect three sets', function () {
@@ -310,11 +309,11 @@ describe('skip map', function () {
 
       a.add('5a600e10', 16);
       a.add('5a600e12', 10);
-      a.add('5a600e14', 9);
+      a.add(obj, 9);
       a.add('5a600e15', 14);
       a.add('5a600e17', 20);
       a.add('5a600e18', 13);
-      a.add('5a600e19', 15);
+      a.add('5a600e14', 15);
       a.add('5a600e1a', 19);
       a.add('5a600e1b', 7);
       a.add('5a600e1c', 13);
@@ -323,10 +322,10 @@ describe('skip map', function () {
       b.add('5a600e10', 0);
       b.add('5a600e11', 15);
       b.add('5a600e13', 5);
-      b.add('5a600e14', 3);
+      b.add(obj, 3);
       b.add('5a600e15', 14);
       b.add('5a600e17', 12);
-      b.add('5a600e19', 12);
+      b.add('5a600e14', 12);
       b.add('5a600e1b', 16);
       b.add('5a600e1c', 12);
       b.add('5a600e1d', 17);
@@ -335,7 +334,7 @@ describe('skip map', function () {
       c.add('5a600e10', 7);
       c.add('5a600e12', 20);
       c.add('5a600e13', 9);
-      c.add('5a600e14', 19);
+      c.add(obj, 19);
       c.add('5a600e16', 19);
       c.add('5a600e17', 1);
       c.add('5a600e18', 18);
@@ -343,7 +342,7 @@ describe('skip map', function () {
       c.add('5a600e1c', 15);
       c.add('5a600e1f', 4);
 
-      expect(SortedSet.intersect(c, a, b)).to.eql(['5a600e10', '5a600e14',
+      expect(SortedSet.intersect(c, a, b)).to.eql(['5a600e10', obj,
         '5a600e17', '5a600e1c']);
 
       expect(SortedSet.intersect(c, a, b)).to.eql(c.intersect(a, b));
@@ -357,11 +356,11 @@ describe('skip map', function () {
 
       a.add('5a600e10', 16);
       a.add('5a600e12', 10);
-      a.add('5a600e14', 9);
+      a.add(obj, 9);
       a.add('5a600e15', 14);
       a.add('5a600e17', 20);
       a.add('5a600e18', 13);
-      a.add('5a600e19', 15);
+      a.add('5a600e14', 15);
       a.add('5a600e1a', 19);
       a.add('5a600e1b', 7);
       a.add('5a600e1c', 13);
@@ -370,10 +369,10 @@ describe('skip map', function () {
       b.add('5a600e10', 0);
       b.add('5a600e11', 15);
       b.add('5a600e13', 5);
-      b.add('5a600e14', 3);
+      b.add(obj, 3);
       b.add('5a600e15', 14);
       b.add('5a600e17', 12);
-      b.add('5a600e19', 12);
+      b.add('5a600e14', 12);
       b.add('5a600e1b', 16);
       b.add('5a600e1c', 12);
       b.add('5a600e1d', 17);
@@ -382,7 +381,7 @@ describe('skip map', function () {
       c.add('5a600e10', 7);
       c.add('5a600e12', 20);
       c.add('5a600e13', 9);
-      c.add('5a600e14', 19);
+      c.add(obj, 19);
       c.add('5a600e16', 19);
       c.add('5a600e17', 1);
       c.add('5a600e18', 18);
@@ -409,7 +408,7 @@ describe('skip map', function () {
       z.add('5a600e11', 6);
       z.add('5a600e12', 17);
       z.add('5a600e13', 11);
-      z.add('5a600e14', 14);
+      z.add(obj, 14);
       z.add('5a600e15', 19);
       z.add('5a600e16', 3);
       z.add('5a600e17', 12);
@@ -432,7 +431,7 @@ describe('skip map', function () {
       z.add('5a600e11', 6);
       z.add('5a600e12', 17);
       z.add('5a600e13', 11);
-      z.add('5a600e14', 14);
+      z.add(obj, 14);
       z.add('5a600e15', 19);
       z.add('5a600e16', 3);
       z.add('5a600e17', 12);
@@ -451,7 +450,7 @@ describe('skip map', function () {
         ['5a600e18', 10],
         ['5a600e13', 11],
         ['5a600e17', 12],
-        ['5a600e14', 14],
+        [obj, 14],
         ['5a600e10', 16],
         ['5a600e12', 17],
       ]);
@@ -464,7 +463,7 @@ describe('skip map', function () {
       z.add('5a600e11', 6);
       z.add('5a600e12', 17);
       z.add('5a600e13', 11);
-      z.add('5a600e14', 14);
+      z.add(obj, 14);
       z.add('5a600e15', 19);
       z.add('5a600e16', 3);
       z.add('5a600e17', 12);
@@ -472,7 +471,7 @@ describe('skip map', function () {
 
       expect(z.rem('5a600e11')).to.equal(6);
       expect(z.rem('5a600e13')).to.equal(11);
-      expect(z.rem('5a600e14')).to.equal(14);
+      expect(z.rem(obj)).to.equal(14);
       expect(z.rem('5a600e15')).to.equal(19);
       expect(z.rem('5a600e16')).to.equal(3);
       expect(z.rem('5a600e17')).to.equal(12);
@@ -494,7 +493,7 @@ describe('skip map', function () {
       z.add('5a600e11', 6);
       z.add('5a600e12', 17);
       z.add('5a600e13', 11);
-      z.add('5a600e14', 14);
+      z.add(obj, 14);
       z.add('5a600e15', 19);
       z.add('5a600e16', 3);
       z.add('5a600e17', 12);
@@ -518,7 +517,7 @@ describe('skip map', function () {
       z.add('5a600e11', 6);
       z.add('5a600e12', 17);
       z.add('5a600e13', 11);
-      z.add('5a600e14', 14);
+      z.add(obj, 14);
       z.add('5a600e15', 19);
       z.add('5a600e16', 3);
       z.add('5a600e17', 12);
@@ -539,7 +538,7 @@ describe('skip map', function () {
       z.add('5a600e11', 6);
       z.add('5a600e12', 17);
       z.add('5a600e13', 11);
-      z.add('5a600e14', 14);
+      z.add(obj, 14);
       z.add('5a600e15', 19);
       z.add('5a600e16', 3);
       z.add('5a600e17', 12);
@@ -563,7 +562,7 @@ describe('skip map', function () {
       z.add('5a600e11', 6);
       z.add('5a600e12', 17);
       z.add('5a600e13', 11);
-      z.add('5a600e14', 14);
+      z.add(obj, 14);
       z.add('5a600e15', 19);
       z.add('5a600e16', 3);
       z.add('5a600e17', 12);
@@ -596,14 +595,14 @@ describe('skip map', function () {
       z.add('5a600e11', 6);
       z.add('5a600e12', 17);
       z.add('5a600e13', 11);
-      z.add('5a600e14', 14);
+      z.add(obj, 14);
       z.add('5a600e15', 19);
       z.add('5a600e16', 3);
       z.add('5a600e17', 12);
       z.add('5a600e18', 10);
 
       expect(function () {
-        z.add('5a600e19', 11);
+        z.add(sym, 11);
       }).to.throw(/unique/);
 
       // quick exit test
@@ -628,7 +627,7 @@ describe('skip map', function () {
         ['5a600e18', 10],
         ['5a600e13', 11],
         ['5a600e17', 12],
-        ['5a600e14', 14],
+        [obj, 14],
         ['5a600e10', 16],
         ['5a600e12', 17],
         ['5a600e15', 19],
@@ -642,7 +641,7 @@ describe('skip map', function () {
       z.add('5a600e11', 6);
       z.add('5a600e12', 17);
       z.add('5a600e13', 11);
-      z.add('5a600e14', 14);
+      z.add(obj, 14);
       z.add('5a600e15', 19);
       z.add('5a600e16', 3);
       z.add('5a600e17', 12);


### PR DESCRIPTION
This PR does the following:

* change storage mechanism from an `Object` with no prototype to a `Map`
* removes the `__proto__` member name restriction
* allows `Symbol` instances for members
* allows `Object` instances for members
* allows `Number` instances for members such that `"2"` and `2` are now unique

Previously only string-based members were supported. For my use-case I'm building a garbage-collection-type tool and wanted the ability to store objects as members.

The main thing this required was to change the underlying storage mechanism from an object (with no prototype) to a `Map` instance. This came with some additional benefits as well, namely members can now be symbols, and the restriction on `__proto__` (the string `__proto__` has no special meaning when calling `Map#get` as compared to looking up an object property). Other natives are no longer stringified as well so `true` and `"true"` are now distinct.

